### PR TITLE
Bug fix, now the folders that weren't on the smb share target will be…

### DIFF
--- a/cmd/syncComparator.go
+++ b/cmd/syncComparator.go
@@ -280,7 +280,7 @@ func (f *syncDestinationComparator) FinalizeTargetDirectory(relativeDir string, 
 		//       Once we add support for directory attributes updation, change that call to cause
 		//       directory attributes updation and not directory creation and remove this code.
 		//
-		if storedObject.entityType == common.EEntityType.Folder() {
+		if storedObject.entityType == common.EEntityType.Folder() && !isTargetCompare {
 			dataChange = false
 		}
 


### PR DESCRIPTION
Currently syncing a non-exiting on target directory will create the directory with the default properties without the original directory SMB properties.
This small change will make sure that directories that didn't exist on the target won't be ignored and will go through the sync process as the files currently go.