### PR TITLE
set LastWriteTime on success to retry failed copy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-storage-blob-go v0.15.0
 	github.com/Azure/go-autorest/autorest/adal v0.9.22
 	github.com/JeffreyRichter/enum v0.0.0-20180725232043-2567042f9cda
-	github.com/aymanjarrousms/azure-storage-file-go v0.0.0-20230517115026-d2f71b77a1c6
+	github.com/aymanjarrousms/azure-storage-file-go v0.0.0-20230614160156-3bb22566bc73
 	github.com/danieljoos/wincred v1.1.2
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/JeffreyRichter/enum v0.0.0-20180725232043-2567042f9cda h1:NOo6+gM9NNP
 github.com/JeffreyRichter/enum v0.0.0-20180725232043-2567042f9cda/go.mod h1:2CaSFTh2ph9ymS6goiOKIBdfhwWUVsX4nQ5QjIYFHHs=
 github.com/PuerkitoBio/goquery v1.7.1/go.mod h1:XY0pP4kfraEmmV1O7Uf6XyjoslwsneBbgeDjLYuN8xY=
 github.com/andybalholm/cascadia v1.2.0/go.mod h1:YCyR8vOZT9aZ1CHEd8ap0gMVm2aFgxBp0T0eFw1RUQY=
-github.com/aymanjarrousms/azure-storage-file-go v0.0.0-20230517115026-d2f71b77a1c6 h1:G54kNqeF0r+0MZ8WKfqm5D/hnWe7K3euUI8vaL8QrxQ=
-github.com/aymanjarrousms/azure-storage-file-go v0.0.0-20230517115026-d2f71b77a1c6/go.mod h1:85yXdSdHfs+r4SOAdNriI2GfN3eZAjETQ9UcYDgXjqE=
+github.com/aymanjarrousms/azure-storage-file-go v0.0.0-20230614160156-3bb22566bc73 h1:6J/+AMl+vVLGu5nWk0pLO1wd6jnJ6nibopQ/HZdATRk=
+github.com/aymanjarrousms/azure-storage-file-go v0.0.0-20230614160156-3bb22566bc73/go.mod h1:85yXdSdHfs+r4SOAdNriI2GfN3eZAjETQ9UcYDgXjqE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/ste/sender-azureFile.go
+++ b/ste/sender-azureFile.go
@@ -171,6 +171,13 @@ func (u *azureFileSenderBase) Prologue(state common.PrologueState) (destinationM
 		creationHeaders.FileAttributes = &revisedAttribs
 	}
 
+	// Set last write time to the minimum time to enable retry copy on next sync
+	// Source last write time will be set in epilogue
+	if info.ShouldTransferLastWriteTime() && u.jptm.Info().PreserveSMBInfo {
+		minimalLwt := time.Unix(0, 0)
+		creationHeaders.FileLastWriteTime = &minimalLwt
+	}
+
 	err = u.DoWithOverrideReadOnly(u.ctx,
 		func() (interface{}, error) {
 			return u.fileURL().Create(u.ctx, info.SourceSize, creationHeaders, u.metadataToApply)


### PR DESCRIPTION
Don't lose data on retry of a failed additive copy, due to newer LastWriteTime by calling:
1. 'Create File' with LWT set to January 1, 1970, UTC.
2. 'Put Range' with x-ms-file-last-write-time=preserve.
3. 'Set File Properties' with the x-ms-file-last-write-time=source-LWT
