### PR TITLE
Support POSIX

### DIFF
--- a/ste/sender-blobFSFromLocal.go
+++ b/ste/sender-blobFSFromLocal.go
@@ -92,4 +92,14 @@ func (u *blobFSUploader) Epilogue() {
 			jptm.FailActiveUpload("Getting hash", errNoHash) // don't return, since need cleanup below
 		}
 	}
+
+	// Write POSIX data
+	if jptm.IsLive() {
+		if jptm.Info().PreservePOSIXProperties {
+			err := u.SetPOSIXProperties()
+			if err != nil {
+				jptm.FailActiveUpload("Setting POSIX Properties", err)
+			}
+		}
+	}
 }


### PR DESCRIPTION
Added support for setting blob metadata:
Used blob pipline for the `setmetadata` call since it is not support on the blobfs pipline