### PR TITLE
Omar/hns renamed dirc

### DIFF
--- a/cmd/zc_enumerator.go
+++ b/cmd/zc_enumerator.go
@@ -507,7 +507,7 @@ func InitResourceTraverser(resource common.ResourceString, location common.Locat
 
 			output = newBlobFSAccountTraverser(resourceURL, *p, *ctx, incrementEnumerationCounter)
 		} else {
-			output = newBlobFSTraverser(resourceURL, *p, *ctx, recursive, incrementEnumerationCounter, isSync, isSource, errorChannel, indexerMap, orderedTqueue, maxObjectIndexerSizeInGB, lastSyncTime, cfdMode, metaDataOnlySync, scannerLogger)
+			output = newBlobFSTraverser(resourceURL, *p, *ctx, recursive, incrementEnumerationCounter, isSync, isSource, errorChannel, indexerMap, possiblyRenamedMap, orderedTqueue, maxObjectIndexerSizeInGB, lastSyncTime, cfdMode, metaDataOnlySync, scannerLogger)
 		}
 	case common.ELocation.S3():
 		resourceURL, err := resource.FullURL()

--- a/cmd/zc_traverser_blobfs_account.go
+++ b/cmd/zc_traverser_blobfs_account.go
@@ -107,7 +107,7 @@ func (t *BlobFSAccountTraverser) Traverse(preprocessor objectMorpher, processor 
 
 	for _, v := range fsList {
 		fileSystemURL := t.accountURL.NewFileSystemURL(v).URL()
-		fileSystemTraverser := newBlobFSTraverser(&fileSystemURL, t.p, t.ctx, true, t.incrementEnumerationCounter, false, false, nil, nil, nil, 0, time.Time{}, common.CFDModeFlags.NotDefined(), false, nil)
+		fileSystemTraverser := newBlobFSTraverser(&fileSystemURL, t.p, t.ctx, true, t.incrementEnumerationCounter, false, false, nil, nil, nil, nil, 0, time.Time{}, common.CFDModeFlags.NotDefined(), false, nil)
 
 		preprocessorForThisChild := preprocessor.FollowedBy(newContainerDecorator(v))
 


### PR DESCRIPTION
Added support for renamed directory.
It should handle correctly the following use case:
source: 
a/b/a.txt
c/b/c.txt
------ copy to target
source: 
a/b/a.txt
c/b/c.txt

target:
a/b/a.txt
c/b/c.txt
------- remove directory "a" recursively from source and rename directory "c" to "a"
source: 
a/b/c.txt

target:
a/b/a.txt
c/b/c.txt
------- without the renamed map we will be comparing directory "a/b" last change time with last sync time and then decide that no changes were made. with renamed map we will be able to identify that the root direct "a" in "a/b" has been renamed and we will enumerate it's children.
source: 
a/b/c.txt

target:
a/b/c.txt